### PR TITLE
RDKOSS-106: set artifactory path of IPK feed for community builds 

### DIFF
--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -27,7 +27,7 @@ OSS_MACHINE = "${@get_oss_machine(d)}"
 OSS_LAYER_ARCH = "${@get_oss_arch(d)}"
 PACKAGE_EXTRA_ARCHS:append = " ${OSS_LAYER_ARCH}"
 OSS_LAYER_EXTENSION = "${OSS_LAYER_ARCH}"
-OSS_IPK_SERVER_PATH = "https://partners.artifactory.comcast.com/artifactory/opkg/rdk-oss-dev/rdkcentral/4/ipks/rdk-arm7ve"
+OSS_IPK_SERVER_PATH = "${RDK_ARTIFACTS_BASE_URL}/rdk-oss-release/${OSS_LAYER_VERSION}/${OSS_MACHINE}/ipks/debug"
 
 # To set the remote feeds
 IPK_FEED_URIS += " \

--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -1,7 +1,7 @@
 # To support layered ipk generation
 # Artifactory URL has to be added here
-#RDK_ARTIFACTS_BASE_URL ?= ""
-#RDK_ARTIFACTS_URL ?= ""
+RDK_ARTIFACTS_BASE_URL ?= ""
+RDK_ARTIFACTS_URL ?= ""
 
 OSS_LAYER_VERSION = "4.4.0"
 def get_oss_machine(d):

--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -1,7 +1,7 @@
 # To support layered ipk generation
 # Artifactory URL has to be added here
-RDK_ARTIFACTS_BASE_URL ?= "test"
-RDK_ARTIFACTS_URL ?= "test"
+RDK_ARTIFACTS_BASE_URL ?= ""
+RDK_ARTIFACTS_URL ?= ""
 
 OSS_LAYER_VERSION = "4.4.0"
 def get_oss_machine(d):

--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -1,7 +1,7 @@
 # To support layered ipk generation
 # Artifactory URL has to be added here
-RDK_ARTIFACTS_BASE_URL ?= ""
-RDK_ARTIFACTS_URL ?= ""
+RDK_ARTIFACTS_BASE_URL ?= "test"
+RDK_ARTIFACTS_URL ?= "test"
 
 OSS_LAYER_VERSION = "4.4.0"
 def get_oss_machine(d):

--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -1,7 +1,7 @@
 # To support layered ipk generation
 # Artifactory URL has to be added here
-RDK_ARTIFACTS_BASE_URL ?= ""
-RDK_ARTIFACTS_URL ?= ""
+#RDK_ARTIFACTS_BASE_URL ?= ""
+#RDK_ARTIFACTS_URL ?= ""
 
 OSS_LAYER_VERSION = "4.4.0"
 def get_oss_machine(d):

--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -1,7 +1,7 @@
 # To support layered ipk generation
 # Artifactory URL has to be added here
-RDK_ARTIFACTS_BASE_URL = ""
-RDK_ARTIFACTS_URL = ""
+RDK_ARTIFACTS_BASE_URL ?= ""
+RDK_ARTIFACTS_URL ?= ""
 
 OSS_LAYER_VERSION = "4.4.0"
 def get_oss_machine(d):

--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -27,7 +27,7 @@ OSS_MACHINE = "${@get_oss_machine(d)}"
 OSS_LAYER_ARCH = "${@get_oss_arch(d)}"
 PACKAGE_EXTRA_ARCHS:append = " ${OSS_LAYER_ARCH}"
 OSS_LAYER_EXTENSION = "${OSS_LAYER_ARCH}"
-OSS_IPK_SERVER_PATH = "${RDK_ARTIFACTS_BASE_URL}/rdk-oss-release/${OSS_LAYER_VERSION}/${OSS_MACHINE}/ipks/debug"
+OSS_IPK_SERVER_PATH = "https://partners.artifactory.comcast.com/artifactory/opkg/rdk-oss-dev/rdkcentral/4/ipks/rdk-arm7ve"
 
 # To set the remote feeds
 IPK_FEED_URIS += " \


### PR DESCRIPTION
Reason for change : set artifactory path of community IPK feed for OSS builds.
Test procedure: IPK feed path should be set appropriately
Risk: Low