### PR TITLE
RDKE-763:  OSS release 4.6.0

### DIFF
--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -3,7 +3,7 @@
 RDK_ARTIFACTS_BASE_URL ?= ""
 RDK_ARTIFACTS_URL ?= ""
 
-OSS_LAYER_VERSION = "4.5.0"
+OSS_LAYER_VERSION = "4.6.0"
 def get_oss_machine(d):
     arch = ""
     default_tune = d.getVar('DEFAULTTUNE')


### PR DESCRIPTION
Reason for the change: Update the oss ipk feed url for oss release 4.6.0