### PR TITLE
RDKOSS-420:  Support for REL_OSS_LAYER_ARCH and OSS_LAYER_ARCH

### DIFF
--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -4,32 +4,12 @@ RDK_ARTIFACTS_BASE_URL ?= ""
 RDK_ARTIFACTS_URL ?= ""
 
 OSS_LAYER_VERSION = "4.7.0"
-def get_oss_machine(d):
-    arch = ""
-    default_tune = d.getVar('DEFAULTTUNE')
-
-    # need to fix: Workaround to check for 64bit machine with multilib configuration
-    multilib_support = d.getVar('MULTILIBS') or ""
-    if multilib_support:
-        arch = "rdk-arm64"
-    elif "armv7athf-neon" in default_tune:
-        arch = "rdk-arm7a"
-    else:
-        arch = "rdk-arm7ve"
-    return arch
-
-def get_oss_arch(d):
-    arch = get_oss_machine(d)
-    arch += "-oss"
-    return arch
-
-OSS_MACHINE = "${@get_oss_machine(d)}"
-OSS_LAYER_ARCH = "${@get_oss_arch(d)}"
-PACKAGE_EXTRA_ARCHS:append = " ${OSS_LAYER_ARCH}"
-OSS_LAYER_EXTENSION = "${OSS_LAYER_ARCH}"
-OSS_IPK_SERVER_PATH = "${RDK_ARTIFACTS_BASE_URL}/rdk-oss-release/${OSS_LAYER_VERSION}/${OSS_MACHINE}/ipks"
+REL_OSS_MACHINE = "${@get_oss_machine(d)}"
+REL_OSS_LAYER_ARCH = "${@get_oss_arch(d)}"
+PACKAGE_EXTRA_ARCHS:append = "${@ '' if '${REL_OSS_LAYER_ARCH}' == '${OSS_LAYER_ARCH}' else ' ${REL_OSS_LAYER_ARCH}'}"
+REL_OSS_LAYER_EXTENSION = "${REL_OSS_LAYER_ARCH}"
+REL_OSS_IPK_SERVER_PATH = "${RDK_ARTIFACTS_BASE_URL}/rdk-oss-release/${OSS_LAYER_VERSION}/${REL_OSS_MACHINE}/ipks"
 
 # To set the remote feeds
 IPK_FEED_URIS += " \
-                ${OSS_LAYER_EXTENSION}##${OSS_IPK_SERVER_PATH} "
-
+                ${REL_OSS_LAYER_EXTENSION}##${REL_OSS_IPK_SERVER_PATH} "


### PR DESCRIPTION
Reason for change: Added support for consuming release OSS IPK packages using the architecture specified in REL_OSS_LAYER_ARCH, and for building OSS with an extended architecture defined by OSS_LAYER_ARCH.