### PR TITLE
RDKOSS-490: Move OSS_LAYER_VERSION to reference layer

### DIFF
--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -3,7 +3,6 @@
 RDK_ARTIFACTS_BASE_URL ?= ""
 RDK_ARTIFACTS_URL ?= ""
 
-OSS_LAYER_VERSION = "4.8.0"
 REL_OSS_MACHINE = "${@get_oss_machine(d)}"
 REL_OSS_LAYER_ARCH = "${@get_oss_arch(d)}"
 PACKAGE_EXTRA_ARCHS:append = "${@ '' if '${REL_OSS_LAYER_ARCH}' == '${OSS_LAYER_ARCH}' else ' ${REL_OSS_LAYER_ARCH}'}"


### PR DESCRIPTION
Reason for the change - The meta-oss-reference-release repository has been excluded from the manifest to support the new OSS consumption model. Consequently, the OSS_LAYER_VERSION parameter previously defined in that repository is no longer available to the build. To address this, the OSS_LAYER_VERSION parameter has been moved to the reference layer to ensure continued availability during the build process.