### PR TITLE
With this change REL_OSS_IPK_SERVER_PATH can be override from local.conf for custom/local builds.

### DIFF
--- a/conf/machine/include/oss.inc
+++ b/conf/machine/include/oss.inc
@@ -7,7 +7,7 @@ REL_OSS_MACHINE = "${@get_oss_machine(d)}"
 REL_OSS_LAYER_ARCH = "${@get_oss_arch(d)}"
 PACKAGE_EXTRA_ARCHS:append = "${@ '' if '${REL_OSS_LAYER_ARCH}' == '${OSS_LAYER_ARCH}' else ' ${REL_OSS_LAYER_ARCH}'}"
 REL_OSS_LAYER_EXTENSION = "${REL_OSS_LAYER_ARCH}"
-REL_OSS_IPK_SERVER_PATH = "${RDK_ARTIFACTS_BASE_URL}/rdk-oss-rel/${OSS_LAYER_VERSION}/${REL_OSS_MACHINE}/ipks"
+REL_OSS_IPK_SERVER_PATH ?= "${RDK_ARTIFACTS_BASE_URL}/rdk-oss-rel/${OSS_LAYER_VERSION}/${REL_OSS_MACHINE}/ipks"
 
 # To set the remote feeds
 IPK_FEED_URIS += " \


### PR DESCRIPTION
SignOff-By : Marcin Mikuła mmikula@libertyglobal.com